### PR TITLE
Upgrade tailwind4 manual

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,20 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 
-import tailwind from '@astrojs/tailwind';
+import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://astro-v5-blog-starter.jldec.me/',
+
   build: {
     format: 'file',
   },
+
   trailingSlash: 'never',
-  integrations: [tailwind()],
+  integrations: [],
+
+  vite: {
+    plugins: [tailwindcss()],
+  },
 });

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "ship": "astro build && wrangler pages deploy"
   },
   "devDependencies": {
-    "@astrojs/tailwind": "^5.1.4",
-    "@tailwindcss/typography": "^0.5.15",
-    "astro": "^5.1.1",
-    "tailwindcss": "^3.4.17",
-    "wrangler": "^3.99.0"
+    "@tailwindcss/typography": "^0.5.16",
+    "@tailwindcss/vite": "^4.0.6",
+    "astro": "^5.2.5",
+    "tailwindcss": "^4.0.6",
+    "wrangler": "^3.107.3"
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@config "../../tailwind.config.mjs";


### PR DESCRIPTION
Upgrade to tailwind css v4.x
See https://docs.astro.build/en/guides/integrations-guide/tailwind/
and https://docs.astro.build/en/guides/styling/#tailwind

### steps
- remove old tailwind packages from package.json and from astro.config
- bump astro to v5.2.5 and run `npx astro add tailwind`
- that replaces deprecated astro tailwind integration with "official" @tailwindcss/vite plugin
- add back latest typography plugin and keep `tailwind.config.mjs` (necessary to customize typography styles)
- fix global styles.css
```css
@import "tailwindcss";
@config "../../tailwind.config.mjs";
```

Had to do this manually because running the [upgrade tool](https://tailwindcss.com/docs/upgrade-guide#using-the-upgrade-tool) didn't work for me (presumably because the old astro vite integration hides the vite config)

Inspired by https://x.com/adamwathan/status/1886899688407699658 and https://github.com/tailwindlabs/tailwindcss-forms/pull/177/files

![Screenshot 2025-02-11 at 12 50 24](https://github.com/user-attachments/assets/f83f74f6-bf07-46f1-bfd4-9c209f7c1057)
